### PR TITLE
ActiveStorage で画像アップロードを実装する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit :sign_up, keys: %i[name email password password_confirmation]
-    devise_parameter_sanitizer.permit :account_update, keys: %i[name email password password_confirmation zipcode address introduction]
+    devise_parameter_sanitizer.permit :account_update, keys: %i[name email password password_confirmation zipcode address introduction avatar]
     devise_parameter_sanitizer.permit :sign_in, keys: %i[email password]
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,6 +6,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     super
   end
 
+  def update
+    super
+    resource.avatar.attach(account_update_params[:avatar]) if account_update_params[:avatar].present?
+  end
+
   protected
 
   def update_resource(resource, params)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :books, dependent: :destroy
+  has_one_attached :avatar
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, and :omniauthable

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -35,6 +35,11 @@
   <% end %>
 
   <div class="field">
+    <%= f.label :avatar %>
+    <%= f.file_field :avatar %>
+  </div>
+
+  <div class="field">
     <%= f.label :password %><%=t 'devise.registrations.edit.leave_blank_if_you_don_t_want_to_change_it' %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,7 @@
 <p>
+  <%= image_tag @user.avatar, size: '320x280' %>
+</p>
+<p>
   <strong><th><%=User.human_attribute_name(:name) %>:</th></strong>
   <%= @user.name %>
 </p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <p>
-  <%= image_tag @user.avatar, size: '320x280' %>
+  <%= image_tag @user.avatar, size: '320x280' if @user.avatar.attached? %>
 </p>
 <p>
   <strong><th><%=User.human_attribute_name(:name) %>:</th></strong>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -64,7 +64,7 @@ ja:
       updated_not_active: パスワードが正しく変更されました。
     registrations:
       user:
-        updated: パスワードが正しく変更されました。
+        updated: プロフィール情報を更新しました。
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
         leave_blank_password: (変更しない場合は何も入力しないでください)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -72,6 +72,7 @@ ja:
         zipcode: 郵便番号
         address: 住所
         introduction: 自己紹介
+        avatar: アイコン画像
         confirmation_sent_at: パスワード確認送信時刻
         confirmation_token: パスワード確認用トークン
         confirmed_at: パスワード確認時刻

--- a/db/migrate/20201105234844_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201105234844_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
@@ -10,7 +12,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +22,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index %i[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness', unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20201105234844_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201105234844_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_03_001227) do
+ActiveRecord::Schema.define(version: 2020_11_05_234844) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title", null: false
@@ -41,4 +62,5 @@ ActiveRecord::Schema.define(version: 2020_11_03_001227) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## ActiveStorage で画像アップロードを実装する
やったこと
- Active Storageのインストール
- has_one_attachedをUserモデルに追加
- i18nの対応
- プロフィール編集ページに画像アップロードフォームの追加
- マイページへの画像表示
 
